### PR TITLE
fix: action handler fails if source is undefined

### DIFF
--- a/index.js
+++ b/index.js
@@ -89,7 +89,12 @@ module.exports = function (app) {
     if(pluginOptions.maretronCompatibility  === true){
 
       //the command must be sent to the device, it cannot be sent to the broadcast
-      dst = parseInt(source['$source'].split(".")[1])
+      if (_.isUndefined(source)) {
+        const parts = dSource.split(".")
+        dst = parseInt(parts[parts.length - 1])
+      } else {
+        dst = parseInt(source['$source'].split(".")[1])
+      }
 
       //the command parameter for the switch number is shifted by one due to the first parameter being the instance
       switchNum++


### PR DESCRIPTION
Original error message:

```
Sep 21 20:31:17 (node:31255) UnhandledPromiseRejectionWarning: TypeError: Cannot read property '$source' of undefined at actionHandler (/data/conf/signalk/node_modules/signalk-n2k-switching/index.js:91:28) at app.registerActionHandler (/data/conf/signalk/node_modules/signalk-n2k-switching/index.js:180:50) at createRequest.then.request (/usr/lib/node_modules/signalk-server/lib/put.js:165:38) at process._tickCallback (internal/process/next_tick.js:68:7)
```