### PR TITLE
Support sourceless PUT and confirm Maretron switching via PGN 126208 ACK

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -29,6 +29,10 @@ module.exports = function (app: any) {
   let registeredPaths: string[] = []
   let pluginOptions: any
 
+  // Waiters for PGN 126208 Acknowledge responses from Maretron-style switch
+  // banks, keyed by device source address (dst of the original command).
+  const pendingAcks = new Map<number, Array<() => void>>()
+
   plugin.id = PLUGIN_ID
   plugin.name = PLUGIN_NAME
   plugin.description = 'SignalK Plugin to enable N2K Switching'
@@ -107,9 +111,9 @@ module.exports = function (app: any) {
     app.emit('nmea2000JsonOut', pgn)
 
     //maretron switch control uses pgn 126208 command to toggle the state via 127501
+    let dst: number | undefined
     if (pluginOptions.maretronCompatibility === true) {
       //the command must be sent to the device, it cannot be sent to the broadcast
-      let dst: number | undefined
       if (source === undefined && dSource) {
         app.debug(
           "%s is undefined, either we didn't ever got a value or getSelfPath isn't working because vessel uuid/mmsi is missing",
@@ -160,6 +164,39 @@ module.exports = function (app: any) {
       }
     }
 
+    // Some switch banks (e.g. Maretron) broadcast PGN 127501 periodically
+    // rather than on-change, so state confirmation by polling can take
+    // 15-30s. Wait up to ~20s before giving up.
+    let settled = false
+    let ackWaiter: (() => void) | undefined
+    const settle = (reply: any) => {
+      if (settled) return
+      settled = true
+      clearInterval(interval)
+      if (ackWaiter !== undefined && dst !== undefined) {
+        const cur = pendingAcks.get(dst)
+        if (cur) {
+          const i = cur.indexOf(ackWaiter)
+          if (i >= 0) cur.splice(i, 1)
+          if (cur.length === 0) pendingAcks.delete(dst)
+        }
+      }
+      cb(reply)
+    }
+
+    // When Maretron compatibility is on, the device acknowledges our 126208
+    // command PGN within ~500ms via an Acknowledge group function. Short
+    // circuit to SUCCESS as soon as that ACK arrives.
+    if (pluginOptions.maretronCompatibility === true && dst !== undefined) {
+      ackWaiter = () => {
+        app.debug('SUCCESS (126208 ACK)')
+        settle({ state: 'SUCCESS' })
+      }
+      const waiters = pendingAcks.get(dst) ?? []
+      waiters.push(ackWaiter)
+      pendingAcks.set(dst, waiters)
+    }
+
     let retryCount = 0
     const interval = setInterval(() => {
       let val = app.getSelfPath(path)
@@ -169,16 +206,12 @@ module.exports = function (app: any) {
       }
       if (val !== undefined && val == new_int) {
         app.debug('SUCCESS')
-        cb({ state: 'SUCCESS' })
-        clearInterval(interval)
-      } else {
-        if (retryCount++ > 5) {
-          cb({
-            state: 'FAILURE',
-            message: 'Did not receive change confirmation'
-          })
-          clearInterval(interval)
-        }
+        settle({ state: 'SUCCESS' })
+      } else if (retryCount++ > 19) {
+        settle({
+          state: 'FAILURE',
+          message: 'Did not receive change confirmation'
+        })
       }
     }, 1000)
 
@@ -194,6 +227,32 @@ module.exports = function (app: any) {
   */
   plugin.start = function (options: any) {
     pluginOptions = options
+
+    // Listen for PGN 126208 Acknowledge responses from Maretron switch
+    // banks so pending PUT requests can confirm in <1s instead of waiting
+    // for the next 15s periodic status broadcast.
+    const onN2KIn = (pgn: any) => {
+      if (
+        !pgn ||
+        pgn.pgn !== 126208 ||
+        pgn.src === undefined ||
+        pgn.fields === undefined ||
+        pgn.fields.functionCode !== 'Acknowledge' ||
+        pgn.fields.pgn !== 127501
+      ) {
+        return
+      }
+      const waiters = pendingAcks.get(pgn.src)
+      if (!waiters || waiters.length === 0) return
+      // Maretron processes commands sequentially, so pair each ACK with
+      // the oldest pending waiter for this device rather than resolving
+      // all of them at once.
+      const waiter = waiters.shift()
+      if (waiters.length === 0) pendingAcks.delete(pgn.src)
+      if (waiter) waiter()
+    }
+    app.on('N2KAnalyzerOut', onN2KIn)
+    onStop.push(() => app.removeListener('N2KAnalyzerOut', onN2KIn))
 
     const command = {
       context: 'vessels.self',
@@ -257,6 +316,7 @@ module.exports = function (app: any) {
     onStop.forEach((f) => f())
     onStop = []
     registeredPaths = []
+    pendingAcks.clear()
   }
 
   return plugin

--- a/src/index.ts
+++ b/src/index.ts
@@ -49,10 +49,18 @@ module.exports = function (app: any) {
   function actionHandler(
     context: string,
     path: string,
-    dSource: string,
+    dSource: string | undefined,
     value: any,
     cb: (res: any) => void
   ) {
+    if (!dSource) {
+      const current = app.getSelfPath(path)
+      if (current && current.$source) {
+        dSource = current.$source
+        app.debug('resolved source from current data: %s', dSource)
+      }
+    }
+
     app.debug(`setting ${path} to ${value}`)
 
     const parts = path.split('.')
@@ -101,48 +109,55 @@ module.exports = function (app: any) {
     //maretron switch control uses pgn 126208 command to toggle the state via 127501
     if (pluginOptions.maretronCompatibility === true) {
       //the command must be sent to the device, it cannot be sent to the broadcast
-      let dst: number
-      if (source === undefined) {
+      let dst: number | undefined
+      if (source === undefined && dSource) {
         app.debug(
           "%s is undefined, either we didn't ever got a value or getSelfPath isn't working because vessel uuid/mmsi is missing",
           path
         )
         const parts = dSource.split('.')
         dst = parseInt(parts[parts.length - 1])
+      } else if (source === undefined) {
+        app.debug(
+          'skipping Maretron command: %s has no current value or source to determine destination',
+          path
+        )
       } else {
         const parts = source['$source'].split('.')
         dst = parseInt(parts[parts.length - 1])
       }
 
-      //the command parameter for the switch number is shifted by one due to the first parameter being the instance
-      switchNum++
+      if (dst !== undefined) {
+        //the command parameter for the switch number is shifted by one due to the first parameter being the instance
+        switchNum++
 
-      const commandPgn = convertCamelCase(
-        app,
-        new PGN_126208_NmeaCommandGroupFunction(
-          {
-            pgn: 127501,
-            priority: 8,
-            numberOfParameters: 2,
-            list: [
-              {
-                parameter: 1,
-                value: instance
-              },
-              {
-                parameter: switchNum,
-                value: new_value
-              }
-            ]
-          },
-          dst
+        const commandPgn = convertCamelCase(
+          app,
+          new PGN_126208_NmeaCommandGroupFunction(
+            {
+              pgn: 127501,
+              priority: 8,
+              numberOfParameters: 2,
+              list: [
+                {
+                  parameter: 1,
+                  value: instance
+                },
+                {
+                  parameter: switchNum,
+                  value: new_value
+                }
+              ]
+            },
+            dst
+          )
         )
-      )
 
-      setTimeout(function () {
-        app.debug('sending command %j', commandPgn)
-        app.emit('nmea2000JsonOut', commandPgn)
-      }, 1000)
+        setTimeout(function () {
+          app.debug('sending command %j', commandPgn)
+          app.emit('nmea2000JsonOut', commandPgn)
+        }, 1000)
+      }
     }
 
     let retryCount = 0
@@ -150,7 +165,7 @@ module.exports = function (app: any) {
       let val = app.getSelfPath(path)
       app.debug('checking %s %j should be %j', path, val, new_int)
       if (val) {
-        val = val.values ? val.values[dSource].value : val.value
+        val = val.values && dSource ? val.values[dSource]?.value : val.value
       }
       if (val !== undefined && val == new_int) {
         app.debug('SUCCESS')


### PR DESCRIPTION
## Motivation

Two related improvements for PUT requests against N2K switch banks, split into separate commits.

### 1. Sourceless PUT (`fix: handle sourceless PUT invocation defensively`)

Standard SignalK PUT clients (e.g. SensESP's `SKPutRequest<int>`) don't specify the N2K `source` in the request body. When such a request arrived, the action handler assumed `dSource` was always defined and crashed on the per-source value lookup in retry polling and on the Maretron compatibility path.

With a single-source path, the SignalK server already dispatches sourceless PUTs to the one registered handler (the `Object.keys(handlers).length === 1` branch in `put.ts`), so no registration-side change is needed — just make the handler tolerate `undefined`.

- Accept `undefined` `dSource`.
- Resolve it from `getSelfPath(path).$source` when available.
- Guard retry polling with optional chaining.
- Skip the Maretron 126208 command when no destination can be determined (the comment notes it cannot go to broadcast).

### 2. Fast confirmation via PGN 126208 ACK (`feat: confirm Maretron switching via PGN 126208 ACK`)

Maretron switch banks broadcast PGN 127501 state **periodically** (~15s per the canboat spec, confirmed on live hardware) rather than on change, so polling-based confirmation often missed the new value within the old ~6s retry budget and returned 502 *"Did not receive change confirmation"* even when the relay had actually flipped. On our test bench worst-case confirmation was ~35 seconds.

However, Maretron devices **acknowledge the 126208 command** within ~500ms via the NMEA Acknowledge group function (PGN 126208 with `functionCode=Acknowledge`, `pgn=127501`). Listening for that ACK via `N2KAnalyzerOut` lets us resolve the pending request almost immediately.

- Register an `N2KAnalyzerOut` listener in `plugin.start`, cleaned up in `plugin.stop`.
- Match inbound 126208 ACKs by `src` address (the device we commanded) and target PGN.
- FIFO-pair ACKs with pending waiters per-device in case of concurrent commands.
- Fall back to polling for devices that don't ACK; extend its budget from ~7s to ~20s to accommodate the 15s periodic status cadence.

No new dependencies; uses the server's existing `N2KAnalyzerOut` event.

## Testing

Tested on a live system with 16 switch banks behind a Yacht Devices YDWG02/YDEN02 gateway (FW 1.77, TCP), against Maretron-branded switch bank controllers. The physical load on bank 73, switch 5 is saloon courtesy lights.

- Before PR: sourceless PUT returned 405.
- After `fix:` commit: sourceless PUT returned 202 → 502 timeouts (~20s wait) — sourceless works but inherits the existing polling-timeout problem.
- After `feat:` commit: sourceless and sourced PUT both complete in 1-2s with status 200 across a 4-toggle sequence. The 126208 ACK short-circuit fired on state-changing commands; repeat toggles into the already-current state resolved via cached polling.
- Sourced PUT continues to work unchanged.

## Notes

- UDP mode on YDWG02 turns out to be one-way (CAN→UDP only) in our firmware — writes only worked in TCP mode. Not a plugin change, but worth noting if others hit the same "PUT accepted but switch never flips" symptom.
- If the upstream Maretron device is unresponsive, the polling fallback still fires the 502 at ~20s.