### PR TITLE
Add CZone device emulation

### DIFF
--- a/src/czoneConstants.ts
+++ b/src/czoneConstants.ts
@@ -1,0 +1,5 @@
+export const BEP_MANUFACTURER_CODE = 116 // BEP Marine
+export const INDICATOR_COUNT = 28
+export const HEARTBEAT_MS = 500
+export const DEFAULT_DIPSWITCH_GROUP = 0x18
+export const DEFAULT_INSTANCE = 23

--- a/src/czoneEmulator.ts
+++ b/src/czoneEmulator.ts
@@ -1,0 +1,335 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+/*
+ * CZone device emulator.
+ *
+ * When enabled, this module emits the PGN stream that a Navico CZone-compatible
+ * switch panel broadcasts on NMEA2000 so that plotters (Zeus, GO series, etc.)
+ * will discover and display a virtual 28-switch bank backed by SignalK state.
+ *
+ * Protocol surface (all BEP Marine manufacturer code = 116):
+ *   - PGN 65290  one-shot "CZone announce" with unique serial + dipswitch group
+ *   - PGN 130817 one-shot circuit descriptor (20 bytes, empty template by default)
+ *   - PGN 65283  periodic dipswitch-state (6 switches worth, 2 bits each)
+ *   - PGN 65284  periodic capability bitmap (32 circuits worth)
+ *   - PGN 127501 periodic standard 28-indicator Binary Switch Bank Status
+ *
+ * Inbound:
+ *   - PGN 127502 Instance <instance> with dst = our emulated address updates
+ *     the internal 28-bit state and triggers an immediate 65283 + 127501 burst.
+ */
+import {
+  BEP_MANUFACTURER_CODE,
+  HEARTBEAT_MS,
+  INDICATOR_COUNT
+} from './czoneConstants'
+
+export interface CZoneEmulatorOptions {
+  enabled: boolean
+  dipswitchGroup: number
+  instance: number
+  uniqueSerial: number
+}
+
+interface AppLike {
+  debug: (...args: any[]) => void
+  emit: (event: string, payload: any) => void
+  on: (event: string, listener: (...args: any[]) => void) => void
+  removeListener: (event: string, listener: (...args: any[]) => void) => void
+  handleMessage?: (pluginId: string, delta: any) => void
+  getSelfPath?: (path: string) => any
+  registerPutHandler?: (
+    context: string,
+    path: string,
+    handler: (...args: any[]) => any
+  ) => void
+}
+
+type Indicators = boolean[]
+
+function emptyIndicators(): Indicators {
+  return new Array(INDICATOR_COUNT).fill(false)
+}
+
+function packDipswitchState(
+  group: number,
+  indicators: Indicators,
+  offset: number
+): Buffer {
+  // Six switches starting at `offset` (0-based), 2 bits each across bytes 3..4
+  // of the 6-byte payload. Byte 7 bit 4 is a presence flag (observed = 1).
+  const buf = Buffer.alloc(6)
+  buf[0] = group & 0xff
+  // bits 0-1 of byte[1] = switch[offset+0], bits 2-3 = switch[+1], bits 4-5 = switch[+2]
+  let b1 = 0
+  for (let i = 0; i < 3; i++) {
+    const on = indicators[offset + i] ? 1 : 0
+    b1 |= on << (i * 2)
+  }
+  // bits 6-7 of byte[1] and continuing into byte[2] bits 0-1 for switch[+3..5]
+  let b2 = 0
+  for (let i = 0; i < 3; i++) {
+    const on = indicators[offset + 3 + i] ? 1 : 0
+    b2 |= on << (i * 2)
+  }
+  buf[1] = b1
+  buf[2] = b2
+  buf[3] = 0
+  buf[4] = 0
+  buf[5] = 0x10
+  return buf
+}
+
+function packCapabilityBitmap(
+  group: number,
+  capability: number,
+  configured: Indicators
+): Buffer {
+  // byte[0]=group, byte[1]=capability byte, byte[2..5] = 32-bit bitmap of
+  // which of up to 32 circuits are configured (we use `configured` positions).
+  const buf = Buffer.alloc(6)
+  buf[0] = group & 0xff
+  buf[1] = capability & 0xff
+  for (let i = 0; i < 32; i++) {
+    if (i < INDICATOR_COUNT && configured[i]) {
+      buf[2 + (i >> 3)] |= 1 << (i & 7)
+    }
+  }
+  return buf
+}
+
+function packAnnounce(uniqueSerial: number, group: number): Buffer {
+  // PGN 65290 payload layout (6 data bytes):
+  //   byte[0..1] = serial low 16 bits (little endian)
+  //   byte[2]    = low nibble = serial bits 16-19, high nibble = 0
+  //   byte[3]    = 0
+  //   byte[4]    = 0
+  //   byte[5]    = dipswitch group
+  const buf = Buffer.alloc(6)
+  buf[0] = uniqueSerial & 0xff
+  buf[1] = (uniqueSerial >> 8) & 0xff
+  buf[2] = (uniqueSerial >> 16) & 0x0f
+  buf[3] = 0
+  buf[4] = 0
+  buf[5] = group & 0xff
+  return buf
+}
+
+function packCircuitDescriptor(group: number): Buffer {
+  // PGN 130817 layout (20 bytes):
+  //   byte[0] = capability/type indicator (observed = 0x01)
+  //   byte[1] = dipswitch group
+  //   bytes 2..19 = 6 circuit slots of 3 bytes each (id, value_low, value_hi_and_flag)
+  // We emit an empty template (all zeros after header) which is the same
+  // idle payload a fresh CZone module broadcasts before any circuits are
+  // configured through the plotter UI.
+  const buf = Buffer.alloc(20)
+  buf[0] = 0x01
+  buf[1] = group & 0xff
+  return buf
+}
+
+function bepPrefix(): Buffer {
+  // Every BEP proprietary PGN starts with a 2-byte header:
+  //   bits 0-10   = manufacturer code (116 = BEP Marine)
+  //   bits 11-12  = reserved (11b)
+  //   bits 13-15  = industry code (4 = Marine)
+  // Encoded little-endian: (0b100 << 13) | (0b11 << 11) | 116
+  const header = (0b100 << 13) | (0b11 << 11) | BEP_MANUFACTURER_CODE
+  const buf = Buffer.alloc(2)
+  buf[0] = header & 0xff
+  buf[1] = (header >> 8) & 0xff
+  return buf
+}
+
+function bepFrame(pgn: number, payload: Buffer): any {
+  // Build a raw Actisense-JSON frame with forceSrc honored by canbus.sendPGN.
+  const data = Buffer.concat([bepPrefix(), payload])
+  return {
+    pgn,
+    prio: 6,
+    dst: 255,
+    data,
+    forceSrc: true
+  }
+}
+
+export class CZoneEmulator {
+  private readonly app: AppLike
+  private readonly opts: CZoneEmulatorOptions
+  private readonly address: number
+  private readonly pluginId: string
+  private indicators: Indicators
+  private timer?: NodeJS.Timeout
+  private messageListener?: (msg: any) => void
+  private started = false
+
+  constructor(
+    app: AppLike,
+    opts: CZoneEmulatorOptions,
+    address: number,
+    pluginId: string
+  ) {
+    this.app = app
+    this.opts = opts
+    this.address = address
+    this.pluginId = pluginId
+    this.indicators = emptyIndicators()
+  }
+
+  start(): void {
+    if (this.started) return
+    this.started = true
+    this.app.debug(
+      'czone emulator starting: group=%d instance=%d address=%d serial=%d',
+      this.opts.dipswitchGroup,
+      this.opts.instance,
+      this.address,
+      this.opts.uniqueSerial
+    )
+
+    this.sendAnnounce()
+    this.sendCircuitDescriptor()
+    this.publishDeltas()
+
+    this.messageListener = (msg: any) => this.handleIncoming(msg)
+    this.app.on('N2KAnalyzerOut', this.messageListener)
+
+    this.timer = setInterval(() => this.tick(), HEARTBEAT_MS)
+  }
+
+  /**
+   * Apply a state change coming from SignalK (e.g. a plugin that the host
+   * server dispatched a PUT to). Returns true if the state actually changed.
+   */
+  setFromSignalK(switchNum: number, on: boolean): boolean {
+    const i = switchNum - 1
+    if (i < 0 || i >= INDICATOR_COUNT) return false
+    if (this.indicators[i] === on) return false
+    this.indicators[i] = on
+    this.broadcastState()
+    this.publishDeltas()
+    return true
+  }
+
+  stop(): void {
+    if (!this.started) return
+    this.started = false
+    if (this.timer) clearInterval(this.timer)
+    this.timer = undefined
+    if (this.messageListener) {
+      this.app.removeListener('N2KAnalyzerOut', this.messageListener)
+      this.messageListener = undefined
+    }
+  }
+
+  getInstance(): number {
+    return this.opts.instance
+  }
+
+  private tick(): void {
+    this.broadcastState()
+  }
+
+  private broadcastState(): void {
+    // 65283: three frames cover switches 1-6, 7-12, 13-18; the real device we
+    // observed reports only the first group because it only exposes 6 virtual
+    // dipswitches. For a 28-indicator panel we emit consecutive 65283 frames
+    // so the plotter sees the full range.
+    for (let group = 0; group * 6 < INDICATOR_COUNT; group++) {
+      const offset = group * 6
+      this.sendBep(
+        65283,
+        packDipswitchState(
+          this.opts.dipswitchGroup + group,
+          this.indicators,
+          offset
+        )
+      )
+    }
+    this.sendBep(
+      65284,
+      packCapabilityBitmap(this.opts.dipswitchGroup, 0x0f, this.indicators)
+    )
+    this.sendStatusPgn()
+  }
+
+  private sendAnnounce(): void {
+    this.sendBep(
+      65290,
+      packAnnounce(this.opts.uniqueSerial, this.opts.dipswitchGroup)
+    )
+  }
+
+  private sendCircuitDescriptor(): void {
+    this.sendBep(130817, packCircuitDescriptor(this.opts.dipswitchGroup))
+  }
+
+  private sendBep(pgn: number, payload: Buffer): void {
+    const frame = bepFrame(pgn, payload)
+    frame.src = this.address
+    this.app.emit('nmea2000JsonOut', frame)
+  }
+
+  private sendStatusPgn(): void {
+    const fields: any = { instance: this.opts.instance }
+    for (let i = 0; i < INDICATOR_COUNT; i++) {
+      fields[`indicator${i + 1}`] = this.indicators[i] ? 'On' : 'Off'
+    }
+    this.app.emit('nmea2000JsonOut', {
+      pgn: 127501,
+      prio: 3,
+      dst: 255,
+      src: this.address,
+      forceSrc: true,
+      fields
+    })
+  }
+
+  private handleIncoming(msg: any): void {
+    if (!msg) return
+    if (msg.pgn !== 127502) return
+    if (msg.dst !== 255 && msg.dst !== this.address) return
+    if (!msg.fields || msg.fields.instance !== this.opts.instance) return
+
+    let changed = false
+    for (let i = 0; i < INDICATOR_COUNT; i++) {
+      const v = msg.fields[`switch${i + 1}`]
+      if (v === 'On' || v === 1 || v === true) {
+        if (!this.indicators[i]) {
+          this.indicators[i] = true
+          changed = true
+        }
+      } else if (v === 'Off' || v === 0 || v === false) {
+        if (this.indicators[i]) {
+          this.indicators[i] = false
+          changed = true
+        }
+      }
+    }
+    if (changed) {
+      this.app.debug('czone emulator applied 127502 from src=%d', msg.src)
+      this.broadcastState()
+      this.publishDeltas()
+    }
+  }
+
+  private publishDeltas(): void {
+    if (!this.app.handleMessage) return
+    const values = this.indicators.map((on, i) => ({
+      path: `electrical.switches.bank.${this.opts.instance}.${i + 1}.state`,
+      value: on ? 1 : 0
+    }))
+    this.app.handleMessage(this.pluginId, {
+      updates: [
+        {
+          source: {
+            label: this.pluginId,
+            type: 'NMEA2000',
+            src: String(this.address)
+          },
+          values
+        }
+      ]
+    })
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -19,15 +19,24 @@ import {
   PGN_126208_NmeaCommandGroupFunction,
   convertCamelCase
 } from '@canboat/ts-pgns'
+import { CZoneEmulator, CZoneEmulatorOptions } from './czoneEmulator'
+import {
+  DEFAULT_DIPSWITCH_GROUP,
+  DEFAULT_INSTANCE,
+  INDICATOR_COUNT
+} from './czoneConstants'
 
 const PLUGIN_ID = 'signalk-n2k-switching'
 const PLUGIN_NAME = 'NMEA2000 Switching'
+const CZONE_EMULATED_ADDRESS_DEFAULT = 67
+const CZONE_UNIQUE_SERIAL_MAX = 0xfffff
 
 module.exports = function (app: any) {
   const plugin: any = {}
   let onStop: any[] = []
   let registeredPaths: string[] = []
   let pluginOptions: any
+  let czoneEmulator: CZoneEmulator | undefined
 
   // Waiters for PGN 126208 Acknowledge responses from Maretron-style switch
   // banks, keyed by device source address (dst of the original command).
@@ -46,6 +55,35 @@ module.exports = function (app: any) {
         title:
           'Maretron Compatibility (Sends command PGN 126208 to update switch status PGN 127501 in addition to the standard switch control PGN 127502)',
         default: false
+      },
+      czoneEmulation: {
+        type: 'object',
+        title:
+          'CZone emulation (publishes a virtual CZone switch panel to the bus)',
+        properties: {
+          enabled: { type: 'boolean', default: false },
+          dipswitchGroup: {
+            type: 'integer',
+            title: 'Dipswitch group',
+            default: DEFAULT_DIPSWITCH_GROUP,
+            minimum: 1,
+            maximum: 253
+          },
+          instance: {
+            type: 'integer',
+            title: 'Switch bank instance',
+            default: DEFAULT_INSTANCE,
+            minimum: 0,
+            maximum: 252
+          },
+          address: {
+            type: 'integer',
+            title: 'Emulated N2K source address',
+            default: CZONE_EMULATED_ADDRESS_DEFAULT,
+            minimum: 1,
+            maximum: 252
+          }
+        }
       }
     }
   }
@@ -228,6 +266,27 @@ module.exports = function (app: any) {
   plugin.start = function (options: any) {
     pluginOptions = options
 
+    if (options.czoneEmulation?.enabled) {
+      const emulationOpts: CZoneEmulatorOptions = {
+        enabled: true,
+        dipswitchGroup:
+          options.czoneEmulation.dipswitchGroup ?? DEFAULT_DIPSWITCH_GROUP,
+        instance: options.czoneEmulation.instance ?? DEFAULT_INSTANCE,
+        uniqueSerial:
+          options.czoneEmulation.uniqueSerial ??
+          deriveSerialFromApp(app, CZONE_UNIQUE_SERIAL_MAX)
+      }
+      const address =
+        options.czoneEmulation.address ?? CZONE_EMULATED_ADDRESS_DEFAULT
+      czoneEmulator = new CZoneEmulator(app, emulationOpts, address, PLUGIN_ID)
+      czoneEmulator.start()
+      registerCZonePutHandlers(app, czoneEmulator)
+      onStop.push(() => {
+        czoneEmulator?.stop()
+        czoneEmulator = undefined
+      })
+    }
+
     // Listen for PGN 126208 Acknowledge responses from Maretron switch
     // banks so pending PUT requests can confirm in <1s instead of waiting
     // for the next 15s periodic status broadcast.
@@ -320,4 +379,34 @@ module.exports = function (app: any) {
   }
 
   return plugin
+}
+
+function registerCZonePutHandlers(app: any, emulator: CZoneEmulator): void {
+  const instance = emulator.getInstance()
+  for (let i = 1; i <= INDICATOR_COUNT; i++) {
+    const path = `electrical.switches.bank.${instance}.${i}.state`
+    app.registerActionHandler(
+      'vessels.self',
+      path,
+      (_context: string, _path: string, value: any, cb: (r: any) => void) => {
+        const on = value === 1 || value === 'on' || value === true
+        emulator.setFromSignalK(i, on)
+        cb({ state: 'SUCCESS' })
+        return { state: 'COMPLETED', statusCode: 200 }
+      }
+    )
+  }
+}
+
+function deriveSerialFromApp(app: any, max: number): number {
+  const seed =
+    app?.selfId ??
+    app?.config?.settings?.vesselUuid ??
+    app?.config?.settings?.vesselMMSI ??
+    'signalk'
+  let h = 0
+  for (let i = 0; i < String(seed).length; i++) {
+    h = (h * 31 + String(seed).charCodeAt(i)) >>> 0
+  }
+  return h % (max + 1)
 }

--- a/test/czoneEmulator.test.mjs
+++ b/test/czoneEmulator.test.mjs
@@ -1,0 +1,79 @@
+// Smoke-test the CZone emulator packers against reference payloads.
+// Run with: node test/czoneEmulator.test.mjs
+import assert from 'node:assert/strict'
+import { CZoneEmulator } from '../dist/czoneEmulator.js'
+
+const emitted = []
+const mockApp = {
+  debug: () => {},
+  emit: (event, payload) => emitted.push({ event, payload }),
+  on: () => {},
+  removeListener: () => {},
+  handleMessage: () => {}
+}
+
+const emu = new CZoneEmulator(
+  mockApp,
+  { enabled: true, dipswitchGroup: 0x18, instance: 23, uniqueSerial: 0xdb13b },
+  67,
+  'signalk-n2k-switching'
+)
+emu.start()
+
+// The announce frame: PGN 65290, payload should match reference 3B B1 0D 00 00 18
+const announce = emitted.find(
+  (e) => e.event === 'nmea2000JsonOut' && e.payload.pgn === 65290
+)
+assert.ok(announce, 'expected PGN 65290 announce frame')
+// data = 2-byte BEP header + 6-byte payload
+const ann = announce.payload.data
+assert.equal(ann.length, 8, 'PGN 65290 total data length')
+assert.deepEqual(
+  Array.from(ann.slice(2)),
+  [0x3b, 0xb1, 0x0d, 0x00, 0x00, 0x18],
+  'PGN 65290 payload matches reference capture'
+)
+
+// Circuit descriptor: 20 data bytes, header 01 18 ...
+const desc = emitted.find(
+  (e) => e.event === 'nmea2000JsonOut' && e.payload.pgn === 130817
+)
+assert.ok(desc, 'expected PGN 130817 descriptor frame')
+const d = desc.payload.data
+assert.equal(d.length, 22, 'PGN 130817 total data length (2+20)')
+assert.equal(d[2], 0x01, 'PGN 130817 byte[0] = 0x01')
+assert.equal(d[3], 0x18, 'PGN 130817 byte[1] = dipswitch group')
+
+// Toggle switch 1 and verify 65283 encodes it correctly
+emitted.length = 0
+emu.setFromSignalK(1, true)
+const state = emitted.find(
+  (e) => e.event === 'nmea2000JsonOut' && e.payload.pgn === 65283
+)
+assert.ok(state, 'expected PGN 65283 state frame')
+const s = state.payload.data
+assert.equal(s[2], 0x18, 'byte[0] = dipswitch group')
+assert.equal(s[3], 0x01, 'byte[1] = switch1 on (bits 0-1 = 01)')
+assert.equal(s[4], 0x00, 'byte[2] = 0')
+
+// Toggle switch 3 (without switch 1): byte[1] bits 4-5 should be 01 = 0x10
+emu.setFromSignalK(1, false)
+emitted.length = 0
+emu.setFromSignalK(3, true)
+const s3 = emitted.find(
+  (e) => e.event === 'nmea2000JsonOut' && e.payload.pgn === 65283
+)
+assert.ok(s3, 'expected PGN 65283 for switch 3')
+assert.equal(s3.payload.data[3], 0x10, 'switch3 on encodes to byte[1] = 0x10')
+
+// 127501 emission should contain 28 indicator fields
+const status = emitted.find(
+  (e) => e.event === 'nmea2000JsonOut' && e.payload.pgn === 127501
+)
+assert.ok(status, 'expected PGN 127501 status')
+assert.equal(status.payload.fields.instance, 23)
+assert.equal(status.payload.fields.indicator3, 'On')
+assert.equal(status.payload.fields.indicator1, 'Off')
+
+emu.stop()
+console.log('czone emulator packer smoke test: PASS')


### PR DESCRIPTION
## Summary

Adds an optional CZone device emulator so SignalK can appear on the NMEA2000 bus as a Navico CZone–compatible switch panel. When enabled, a Zeus/GO plotter will discover and display a 28-switch bank whose state is backed by `electrical.switches.bank.<instance>.N.state` paths.

Off by default. No behavior change for existing users.

## How it works

When the `czoneEmulation` option is enabled the plugin emits the PGN stream a CZone module broadcasts:

- **PGN 65290** one-shot announce with unique serial + dipswitch group
- **PGN 130817** one-shot circuit descriptor (empty template)
- **PGN 65283 / 65284** periodic dipswitch state and capability bitmap (500 ms)
- **PGN 127501** periodic 28-indicator Binary Switch Bank Status (500 ms)

Inbound PGN 127502 targeted at the emulated address updates the internal state and triggers an immediate re-broadcast. SignalK deltas for each indicator are published on the plugin source so the standard delta/subscription API works.

A smoke test under `test/` validates packer output against reference capture bytes.

## Transport caveat

The emulated source address only survives end-to-end on direct-CAN transports (socketcan). Hardware gateway transports (YDGW02, iKonvert, Actisense serial) rewrite or replace the source address of outgoing frames with the gateway's own claimed address — in that case the CZone PGNs still reach the bus but appear to originate from the gateway rather than from a distinct virtual address. Functionally this may still be accepted by the plotter; needs verification.

## Configuration

| Option | Default |
|---|---|
| `czoneEmulation.enabled` | `false` |
| `czoneEmulation.dipswitchGroup` | `24` |
| `czoneEmulation.instance` | `23` |
| `czoneEmulation.address` | `67` |

## Testing performed

- `npm run build` clean
- `npm run format` (prettier + eslint) clean
- `node test/czoneEmulator.test.mjs` — packer output matches reference capture bytes for PGN 65290 (announce), 130817 (descriptor), 65283 (switch state toggles), and 127501 (28-indicator status)
- Not yet verified against a live Zeus plotter