### PR TITLE
fix: resolve dst for canName-attributed $source strings (Maretron IPG)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -114,21 +114,31 @@ module.exports = function (app: any) {
     let dst: number | undefined
     if (pluginOptions.maretronCompatibility === true) {
       //the command must be sent to the device, it cannot be sent to the broadcast
+      let resolveSource: string | undefined
       if (source === undefined && dSource) {
         app.debug(
           "%s is undefined, either we didn't ever got a value or getSelfPath isn't working because vessel uuid/mmsi is missing",
           path
         )
-        const parts = dSource.split('.')
-        dst = parseInt(parts[parts.length - 1])
+        resolveSource = dSource
       } else if (source === undefined) {
         app.debug(
           'skipping Maretron command: %s has no current value or source to determine destination',
           path
         )
       } else {
-        const parts = source['$source'].split('.')
-        dst = parseInt(parts[parts.length - 1])
+        resolveSource = source['$source']
+      }
+
+      if (resolveSource !== undefined) {
+        dst = resolveDstFromSource(app, resolveSource)
+        if (dst === undefined) {
+          app.debug(
+            'skipping Maretron command for %s: could not resolve destination address from $source %s',
+            path,
+            resolveSource
+          )
+        }
       }
 
       if (dst !== undefined) {
@@ -320,4 +330,56 @@ module.exports = function (app: any) {
   }
 
   return plugin
+}
+
+/**
+ * Resolve a NMEA 2000 destination address from a SignalK `$source` string.
+ *
+ * Most providers (canboatjs, ydwg02) produce `$source` strings whose last
+ * dot-separated token is the device's current CAN address as a decimal
+ * integer (e.g. `canboatjs.31`). For these, the address is taken directly.
+ *
+ * Some providers (notably canboatjs's `MaretronIPG` and `N2kIpGateway` with
+ * `useCanName: true`) attribute by 64-bit NAME instead, producing strings
+ * like `Maretron-IPG-192.168.0.179.c03c8c0c1139f548`. The hex tail is not a
+ * base-10 integer, so we look up the live address by walking
+ * `app.signalk.retrieve().sources[<label>]` — whose entries are keyed by
+ * numeric CAN address and carry a `canName` — for the entry whose canName
+ * matches the tail, and return its address key.
+ *
+ * Returns `undefined` when no plausible address can be determined.
+ */
+function resolveDstFromSource(app: any, srcString: string): number | undefined {
+  // A $source is `<label>.<tail>`. The label itself can contain dots (e.g.
+  // an IP address: `Maretron-IPG-192.168.0.179`), so split on the LAST dot:
+  // everything before it is the source label (the key into `sources`), and
+  // the final segment is the tail — either a decimal CAN address or, when the
+  // provider uses `useCanName`, the 64-bit NAME (hex).
+  const lastDot = srcString.lastIndexOf('.')
+  const label = lastDot >= 0 ? srcString.slice(0, lastDot) : srcString
+  const tail = lastDot >= 0 ? srcString.slice(lastDot + 1) : srcString
+
+  // Fast path: tail is already a decimal CAN address (0–251 are valid
+  // unicast destinations; 254 is null-address; 255 is broadcast).
+  if (/^\d+$/.test(tail)) {
+    const direct = parseInt(tail, 10)
+    if (direct >= 0 && direct < 252) return direct
+  }
+
+  // Slow path: tail is a canName (hex NAME). The live sources registry is
+  // keyed `sources[<label>][<numeric CAN address>] = { ..., canName }`, so
+  // walk that label's entries for the one whose canName matches the tail and
+  // return its numeric address key — that is the device's current dst.
+  const sources = app?.signalk?.retrieve?.()?.sources?.[label]
+  if (!sources || typeof sources !== 'object') return undefined
+  for (const [addrStr, entry] of Object.entries(
+    sources as Record<string, any>
+  )) {
+    const canName = entry?.canName ?? entry?.n2k?.canName
+    if (canName === tail) {
+      const addr = parseInt(addrStr, 10)
+      if (!isNaN(addr) && addr >= 0 && addr < 252) return addr
+    }
+  }
+  return undefined
 }


### PR DESCRIPTION
Fixes #16.

## Problem

When SignalK attributes a source by 64-bit NAME instead of current CAN address — which canboatjs's `MaretronIPG` and `N2kIpGateway` do when `useCanName: true` — the `$source` string looks like `ipg.c03c8c0c1139f548` rather than `canboatjs.31`. The previous code did `parseInt(tail, 10)` on the hex NAME, got `NaN`, and the underlying serializer encoded `NaN` as `0`. The unicast PGN 126208 group function command then went to `dst=0` and the device ignored it. The broadcast PGN 127502 was sent unchanged, but Maretron banks don't act on the broadcast — they require the unicast 126208 — so toggling the SK path had no on-bus effect.

## Fix

Extract destination resolution into `resolveDstFromSource(app, srcString)`:

1. If the tail of `$source` is a base-10 integer in the valid CAN unicast range (0–251), use it directly. Keeps the existing `canboatjs.31` / `ydwg02.31` path zero-cost.
2. Otherwise, treat the tail as a 64-bit NAME (canName) and walk `app.signalk.retrieve().sources[<bus>]` for an entry whose `n2k.canName` matches. The address that owns that canName is the live `dst`. SK keeps this mapping current across Address Claim events for free.
3. If neither path yields an address, skip the 126208 command and `app.debug` it instead of sending to `dst=0`.

The change is minimal — the existing source/dSource branch is unchanged, only the final `parseInt(tail)` step is replaced with the helper.

## On-the-wire diff (from issue #16)

Before (signalk-n2k-switching against Maretron IPG/DCR100, dst is wrong):
\`\`\`
3,126208,128,0,10,01,0d,f2,01,f8,02,01,0c,02,00      <-- dst=0
3,126208,0,128,7,02,0d,f2,01,01,02,00                 <-- error response from src 0
\`\`\`

After (matches what N2KView puts on the wire):
\`\`\`
3,126208,128,19,10,01,0d,f2,01,f8,02,01,0c,02,00     <-- dst=19 (current CAN address)
3,126208,19,128,7,02,0d,f2,01,00,02,00                <-- ACK from device 19 → IPG 128
\`\`\`

## Verification

- `npm run ci-test` (build + lint + prettier) passes locally.
- Smoke-tested by tapping `electrical.switches.bank.12.1.state` from a custom HMI on Maretron DCR100 via IPG100: relay flips, the 126208 ACK arrives on the bus within ~500ms, and the existing ACK short-circuit in the action handler resolves the PUT.
- Non-IPG paths (`canboatjs.<addr>`, `ydwg02.<addr>`) take the fast path and are unaffected.