### PR TITLE
Add Dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,53 @@
+# Dependabot configuration
+# https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+version: 2
+
+updates:
+  # npm dependencies (package.json)
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+      time: "06:00"
+      timezone: Etc/UTC
+    open-pull-requests-limit: 10
+    labels:
+      - dependencies
+    commit-message:
+      prefix: deps
+      prefix-development: deps-dev
+      include: scope
+    groups:
+      # Batch low-risk dev tooling (linting, formatting, types) into one PR
+      dev-dependencies:
+        dependency-type: development
+        update-types:
+          - minor
+          - patch
+      # Batch production minor/patch bumps together
+      production-dependencies:
+        dependency-type: production
+        update-types:
+          - minor
+          - patch
+
+  # GitHub Actions used by the workflows in .github/workflows
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+      time: "06:00"
+      timezone: Etc/UTC
+    open-pull-requests-limit: 5
+    labels:
+      # require_pr_label.yml enforces exactly one of the recognized labels
+      - dependencies
+    commit-message:
+      prefix: ci
+      include: scope
+    groups:
+      github-actions:
+        patterns:
+          - "*"


### PR DESCRIPTION
Adds \`.github/dependabot.yml\` to keep dependencies current.

- **npm** (\`package.json\`): weekly checks, grouped to reduce PR noise — dev tooling (lint/format/types) in one PR, production minor/patch in another. Major bumps still open individually.
- **GitHub Actions**: weekly checks for the actions used in the workflows, grouped into a single PR.

All Dependabot PRs are labeled \`dependencies\`, which is one of the labels the \`require_pr_label\` workflow accepts.

> Note: this PR itself is unlabeled — the \`dependencies\`/\`chore\` labels don't yet exist as repo labels, so the label check will be red until a maintainer adds one.