### PR TITLE
Modernize GitHub Actions to current major versions

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -9,8 +9,8 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v1
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
         with:
           node-version: '24.x'
           registry-url: 'https://registry.npmjs.org'

--- a/.github/workflows/require_pr_label.yml
+++ b/.github/workflows/require_pr_label.yml
@@ -6,7 +6,7 @@ jobs:
   label:
     runs-on: ubuntu-latest
     steps:
-      - uses: mheap/github-action-required-labels@v1
+      - uses: mheap/github-action-required-labels@v5
         with:
           mode: exactly
           count: 1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,9 +18,9 @@ jobs:
         node-version: [22.x, 24.x]
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v6
         with:
           node-version: ${{ matrix.node-version }}
       - run: npm install


### PR DESCRIPTION
Bumps the pinned action versions in the workflows. Older majors run on deprecated Node action runtimes (Node 12/16/20) and emit deprecation warnings.

| Action | Was | Now |
| --- | --- | --- |
| \`actions/checkout\` | v2, v3 | **v6** |
| \`actions/setup-node\` | v1, v3 | **v6** |
| \`mheap/github-action-required-labels\` | v1 | **v5** |

\`mheap/github-action-required-labels\` v1→v5 is a drop-in: the \`mode\`/\`count\`/\`labels\` inputs are unchanged. \`softprops/action-gh-release\` in \`release_on_tag.yml\` is already on its latest major (v3) and is left untouched.

Version pins only — no behavioral changes.