### PR TITLE
Run CI test matrix weekly via scheduled trigger

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,6 +8,11 @@ on:
     branches: ['master']
   pull_request:
     branches: ['master']
+  schedule:
+    # Run the full matrix weekly (Mondays 06:00 UTC) to catch breakage from
+    # transitive dependency drift even when there are no pushes.
+    - cron: '0 6 * * 1'
+  workflow_dispatch:
 
 jobs:
   build:


### PR DESCRIPTION
Adds a weekly \`schedule\` (Mondays 06:00 UTC) and a manual \`workflow_dispatch\` trigger to the CI workflow, alongside the existing push/pull_request triggers.

The scheduled run exercises the full Node matrix (22.x, 24.x) even when no commits land, catching breakage from transitive dependency drift between releases. \`workflow_dispatch\` allows running it on demand.

Trigger-only change; no version bumps or other edits.