### PR TITLE
Harden CI workflows with least-privilege permissions and limits

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -8,6 +8,7 @@ permissions:
 jobs:
   build:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v1

--- a/.github/workflows/require_pr_label.yml
+++ b/.github/workflows/require_pr_label.yml
@@ -2,9 +2,15 @@ name: Pull Request Labels
 on:
   pull_request:
     types: [opened, labeled, unlabeled, synchronize]
+
+# Least-privilege: the action only reads the PR's labels.
+permissions:
+  contents: read
+  pull-requests: read
 jobs:
   label:
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
       - uses: mheap/github-action-required-labels@v1
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,9 +9,19 @@ on:
   pull_request:
     branches: ['master']
 
+# Least-privilege default: this workflow only needs to read the repo.
+permissions:
+  contents: read
+
+# Cancel an in-progress run when a new commit is pushed to the same ref.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
 
     strategy:
       matrix:


### PR DESCRIPTION
Applies security/robustness best practices to the workflows.

- **test.yml**: top-level \`permissions: contents: read\`; a \`concurrency\` group that cancels superseded runs on the same ref; \`timeout-minutes: 15\`.
- **require_pr_label.yml**: least-privilege \`permissions\` (\`contents: read\`, \`pull-requests: read\`); \`timeout-minutes: 5\`.
- **publish.yml**: \`timeout-minutes: 15\` (its \`id-token: write\` / \`contents: read\` permissions are left intact).

No dependency caching is added: there is no committed \`package-lock.json\` and \`test.yml\` uses \`npm install\`, so \`setup-node\`'s \`cache: 'npm'\` has no lockfile to key on and would fail. \`release_on_tag.yml\` already sets its own permissions/concurrency/timeout and is left unchanged.

No action version bumps and no schedule changes here — those are separate PRs.