### PR TITLE
Fix beta dist-tag detection in publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -24,6 +24,8 @@ jobs:
           npm run build
 
       - name: Publish
+        env:
+          tag: ${{ github.event.release.tag_name }}
         run: |
           if [[ "$tag" == *beta* ]];
             then


### PR DESCRIPTION
The \`Publish\` step in \`publish.yml\` branches on \`[[ "\$tag" == *beta* ]]\`, but \`\$tag\` is never defined in the step's environment. It therefore always evaluated to an empty string, so **every** release published to the \`latest\` dist-tag and the \`npm publish --tag beta\` branch was dead code.

This sets \`tag\` from \`github.event.release.tag_name\` so the existing check actually fires: beta releases publish to the \`beta\` dist-tag, everything else to \`latest\`.

\`\`\`yaml
      - name: Publish
        env:
          tag: ${{ github.event.release.tag_name }}
        run: |
          if [[ "$tag" == *beta* ]]; then
            ...
\`\`\`

Scoped to making the existing \`beta\` check work — I left the logic otherwise unchanged. Note that \`rc\`/\`alpha\` prereleases (which \`release_on_tag.yml\` does mark as GitHub prereleases) still publish to \`latest\` here, matching the prior behavior; happy to extend the check to those too if you'd prefer.